### PR TITLE
Add WP_NO_ADMIN_AJAX_URL variable to set the default url

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,18 @@ $ composer require devgeniem/wp-no-admin-ajax
 - Rewrite all admin-ajax.php queries into custom url so you can allow `/wp-admin/` to only certain IP-addresses.
 - You can use this to confuse bots which might try to use vulnerabilities in admin-ajax.php.
 
-## Hooks & Filters
+## Configuration
+### Variables
+This plugin url is by default `/no-admin-ajax/`. You can use filters to change it or you can set the default value by yourself by using:
+
+```php
+// This turns the no admin ajax url to -> /ajax/
+define('WP_NO_ADMIN_AJAX_URL','ajax');
+```
+
+**Notice:** Value set here can be filtered too, this just sets the starting point for the custom url.
+
+### Hooks & Filters
 You can customize the url by using filter `no-admin-ajax/keyword`.
 ```php
 <?php

--- a/plugin.php
+++ b/plugin.php
@@ -41,7 +41,13 @@ class No_Admin_Ajax {
     add_action( "init", array( $this, "rewrite" ) );
 
     // Url keyword to use for the ajax calls. Is modifiable with filter "no-admin-ajax/keyword"
-    $default_keyword = "no-admin-ajax";
+    if ( defined('WP_NO_ADMIN_AJAX_URL') ) {
+        // keyword doesn't need to contain slashes because they are set in redirect_ajax_url()
+        // trim slashes to avoid confusion
+        $default_keyword = trim(WP_NO_ADMIN_AJAX_URL,'/');
+    } else {
+        $default_keyword = "no-admin-ajax";
+    }
 
     $this->keyword = apply_filters( "no-admin-ajax/keyword", $default_keyword );
   }


### PR DESCRIPTION
This can be changed later on with `apply_filters( "no-admin-ajax/rule", $default_rule );` filter but it's nice to have option to define the default in `wp-config.php` as well.
